### PR TITLE
Client: support detector-style models, and three correctness fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@ The message definitions are similar to [`vision_msgs`][vision_msgs] but it does 
 Please install the `tritonclient[all]` Python package:
 
     python3 -m pip install tritonclient[all]
+
+This client uses the gRPC transport only. On Jetson (JetPack 5.1.x / aarch64,
+Python 3.8) the `[all]` and `[http]` extras fail to build because they pull in
+`gevent`, which has no aarch64 wheel; install just the gRPC client there:
+
+    python3 -m pip install tritonclient[grpc]

--- a/src/triton_api.py
+++ b/src/triton_api.py
@@ -15,6 +15,7 @@ processing of their inptus and outputs, like image classification models:
 
 import enum
 import functools
+import warnings
 
 from typing import Any, List, NamedTuple, Union, cast
 
@@ -23,6 +24,7 @@ import tritonclient.grpc
 
 from PIL import Image
 from tritonclient.grpc import model_config_pb2, service_pb2
+from tritonclient.utils import triton_to_np_dtype
 
 
 def softmax(logits: np.ndarray, axis: int = -1) -> np.ndarray:
@@ -38,20 +40,23 @@ def softmax(logits: np.ndarray, axis: int = -1) -> np.ndarray:
     return exp / np.sum(exp, axis=axis, keepdims=True)
 
 
-def model_dtype_to_np(model_dtype: str) -> object:
-    return {
-        'BOOL':   bool,
-        'INT8':   np.int8,
-        'INT16':  np.int16,
-        'INT32':  np.int32,
-        'INT64':  np.int64,
-        'UINT8':  np.uint8,
-        'UINT16': np.uint16,
-        'FP16':   np.float16,
-        'FP32':   np.float32,
-        'FP64':   np.float64,
-        'BYTES':  np.dtype(object),
-    }[model_dtype]
+def model_dtype_to_np(model_dtype: str) -> np.dtype:
+    # tritonclient ships the full Triton -> numpy mapping (including UINT32,
+    # UINT64, and BF16, which a hand-rolled table here used to omit).
+    np_dtype = triton_to_np_dtype(model_dtype)
+    if np_dtype is None:
+        raise ValueError(f'Unsupported model datatype {model_dtype!r}')
+    return np.dtype(np_dtype)
+
+
+def shape_matches(actual, expected) -> bool:
+    '''
+    Compare a concrete tensor shape against a model-declared one, where -1
+    marks a dimension the model leaves dynamic (any size satisfies it).
+    '''
+    actual, expected = list(actual), list(expected)
+    return len(actual) == len(expected) and \
+        all(e == -1 or a == e for a, e in zip(actual, expected))
 
 
 class ScalingMode(enum.Enum):
@@ -131,8 +136,12 @@ class ModelInput:
 
 class TensorInput(ModelInput):
     def process(self, value: np.ndarray) -> np.ndarray:
-        # If we received a single input and expected a batch, reshape
-        if self.model.can_batch and len(self.metadata.shape) == value.ndim + 1:
+        # If we received a single input and the tensor carries a batch axis --
+        # either implicitly (max_batch_size > 0) or an explicit dynamic leading
+        # dimension -- reshape into a batch of one.
+        shape = self.metadata.shape
+        if len(shape) == value.ndim + 1 and \
+                (self.model.can_batch or shape[0] == -1):
             return value.reshape([1] + list(value.shape))
 
         # Otherwise, pass through unmodified
@@ -189,10 +198,21 @@ class ImageInput(ModelInput):
         else:  # NHWC
             self.height, self.width, self.channels = shape[-3], shape[-2], shape[-1]
 
-        # Triton reports -1 for any dimension the model leaves dynamic, which is
-        # not a usable image size. Fall back to an explicit size= if given.
+        # Triton reports -1 for any dimension the model leaves dynamic, which
+        # is not a usable image size. Fall back to an explicit size= for those
+        # dimensions only; a size= that contradicts a fixed declared dimension
+        # is a configuration error, not an override.
         if self.size is not None:
-            self.width, self.height = self.size
+            want_w, want_h = self.size
+            if (self.width > 0 and self.width != want_w) or \
+                    (self.height > 0 and self.height != want_h):
+                raise ValueError(
+                    f'size={self.size} contradicts the model-declared input '
+                    f'size ({self.width}, {self.height})')
+            if self.width < 1:
+                self.width = want_w
+            if self.height < 1:
+                self.height = want_h
         if self.width < 1 or self.height < 1:
             raise ValueError(
                 f'Model declares dynamic spatial dimensions {shape}; pass '
@@ -201,6 +221,27 @@ class ImageInput(ModelInput):
             raise ValueError(
                 f'Model declares a dynamic channel count in {shape}; '
                 'ImageInput needs a fixed 1- or 3-channel input')
+
+        # How many images one request may carry: the model either batches via
+        # max_batch_size (Triton adds the axis itself), or declares an explicit
+        # leading batch dimension of its own (-1 for unbounded, or a fixed
+        # count). None means unbounded.
+        if model.can_batch:
+            self._capacity = model.max_batch_size
+        elif self._rank == 4:
+            self._capacity = shape[0] if shape[0] > 0 else None
+        else:
+            self._capacity = 1
+
+        # Resolve the tensor dtype once, and catch a scaling mode bound to an
+        # integer tensor here rather than on the first frame: scaling produces
+        # fractional values, so it is only meaningful for a float tensor.
+        self.dtype = model_dtype_to_np(self.metadata.datatype)
+        if self.scaling != ScalingMode.NONE and \
+                not np.issubdtype(self.dtype, np.floating):
+            raise ValueError(
+                f'{self.scaling.name} scaling requires a floating-point input '
+                f'tensor, but the model expects {self.metadata.datatype}')
 
     def _process_one(self, image: Image.Image) -> np.ndarray:
         # Convert the image to the model's expected channel count
@@ -215,16 +256,9 @@ class ImageInput(ModelInput):
         # https://medium.com/neuronio/how-to-deal-with-image-resizing-in-deep-learning-e5177fad7d89
         image = image.resize((self.width, self.height), Image.BILINEAR)
 
-        # Convert the image to a nparray. Scaling produces fractional values, so
-        # it is only meaningful for a float input tensor; catch an integer one
-        # here rather than letting numpy raise an opaque casting error below.
-        dtype = np.dtype(model_dtype_to_np(self.metadata.datatype))
-        if self.scaling != ScalingMode.NONE and not np.issubdtype(dtype,
-                                                                  np.floating):
-            raise ValueError(
-                f'{self.scaling.name} scaling requires a floating-point input '
-                f'tensor, but the model expects {self.metadata.datatype}')
-        array = np.array(image).astype(dtype)
+        # Convert the image to an ndarray, casting straight into the model's
+        # dtype (resolved once at bind time) in a single pass.
+        array = np.array(image, dtype=self.dtype)
 
         # If the image is grayscale, add a channel axis (HW -> HWC)
         if array.ndim == 2:
@@ -252,8 +286,9 @@ class ImageInput(ModelInput):
             value = [value]
         value = cast(List[Image.Image], value)
 
-        if not self.model.can_batch and len(value) != 1:
-            raise ValueError('Input expects exactly one image')
+        if self._capacity is not None and len(value) > self._capacity:
+            raise ValueError(
+                f'Model accepts at most {self._capacity} image(s) per request')
 
         # Process all of the images into a batch in NHWC format
         processed = np.stack([self._process_one(image) for image in value])
@@ -340,6 +375,12 @@ class ClassificationOutput(ModelOutput):
         '''
         fields = c.decode().split(':', maxsplit=2)
         if len(fields) == 2:
+            # Tolerated, but worth one loud note: without label_filename in the
+            # model config every published class_name will be empty.
+            warnings.warn(
+                'Triton returned classifications without class names; the '
+                'model config likely does not set label_filename',
+                stacklevel=2)
             (score, class_id), class_name = fields, ''
         elif len(fields) == 3:
             score, class_id, class_name = fields
@@ -472,21 +513,23 @@ class Model:
             result = kwargs[key] = inputobj.process(value)
             assert isinstance(result, np.ndarray)
 
-            # After processing, assert that each ndarray's shape matches the
-            # model's expected shape.
+            # After processing, check that each ndarray's shape matches the
+            # model's declared shape (shape_matches treats -1 as a wildcard).
+            # A real raise, not an assert: this must survive `python -O`.
             if self.can_batch:
-                assert result.shape[1:] == tuple(inputobj.metadata.shape[1:])
+                if not shape_matches(result.shape[1:],
+                                     inputobj.metadata.shape[1:]):
+                    raise ValueError(
+                        f'processed input shape {list(result.shape)} does not '
+                        f'match model shape '
+                        f'[batch, {", ".join(map(str, inputobj.metadata.shape[1:]))}]')
                 if result.shape[0] > self.max_batch_size:
                     raise ValueError('Too many inputs in batch')
             else:
-                # -1 marks a dimension the model leaves dynamic, which any
-                # size satisfies.
-                actual, expected = \
-                    list(result.shape), list(inputobj.metadata.shape)
-                assert len(actual) == len(expected) and \
-                    all(e == -1 or a == e for a, e in zip(actual, expected)), \
-                    (f'processed input shape {actual} does not '
-                     f'match model shape {expected}')
+                if not shape_matches(result.shape, inputobj.metadata.shape):
+                    raise ValueError(
+                        f'processed input shape {list(result.shape)} does not '
+                        f'match model shape {list(inputobj.metadata.shape)}')
 
             # Create the InferInput object for this input
             req_inputs.append(tritonclient.grpc.InferInput(
@@ -555,11 +598,17 @@ def main():
     parser.add_argument('-x', '--model-version', default='')
     parser.add_argument('-c', '--classes', type=int, default=3,
                         help='classes to request (classification mode)')
+    # ScalingMode.VGG exists in the enum but has no implementation yet, so it
+    # is deliberately not offered here.
     parser.add_argument('-t', '--image-transform',
-                        choices=['NONE', 'NORM', 'INCEPTION', 'VGG'],
+                        choices=['NONE', 'NORM', 'INCEPTION'],
                         default='NONE')
     parser.add_argument('-l', '--layout', choices=['NCHW', 'NHWC'], default=None,
                         help="channel layout when the model config omits `format`")
+    parser.add_argument('-s', '--size', type=int, nargs=2, default=None,
+                        metavar=('WIDTH', 'HEIGHT'),
+                        help='input size for models that declare dynamic '
+                             'spatial dimensions')
     parser.add_argument('--raw', action='store_true',
                         help='return the raw output tensor instead of parsing '
                              'classifications (e.g. for detection models)')
@@ -576,7 +625,8 @@ def main():
     out_name = model.metadata.outputs[0].name
 
     setattr(model, in_name, ImageInput(
-        scaling=ScalingMode[args.image_transform], layout=args.layout))
+        scaling=ScalingMode[args.image_transform], layout=args.layout,
+        size=tuple(args.size) if args.size else None))
     if args.raw:
         setattr(model, out_name, TensorOutput())
     else:
@@ -590,8 +640,12 @@ def main():
         value = getattr(result, out_name)
         if args.raw:
             arr = np.asarray(value)
-            print(f'{out_name}: shape={arr.shape} dtype={arr.dtype} '
-                  f'min={float(arr.min()):.4f} max={float(arr.max()):.4f}')
+            # min/max only exist for a non-empty numeric tensor (a detector
+            # may legitimately return zero rows, or a BYTES output).
+            stats = ''
+            if arr.size and np.issubdtype(arr.dtype, np.number):
+                stats = f' min={float(arr.min()):.4f} max={float(arr.max()):.4f}'
+            print(f'{out_name}: shape={arr.shape} dtype={arr.dtype}{stats}')
         else:
             pprint.pprint(value)
     stop = time.perf_counter()

--- a/src/triton_api.py
+++ b/src/triton_api.py
@@ -25,6 +25,19 @@ from PIL import Image
 from tritonclient.grpc import model_config_pb2, service_pb2
 
 
+def softmax(logits: np.ndarray, axis: int = -1) -> np.ndarray:
+    '''
+    Convert a *complete* vector of logits into probabilities.
+
+    Triton does not apply an activation function to model outputs. Apply this to
+    the full output tensor (bind the output as a TensorOutput); applying it to
+    the truncated top-N scores from ClassificationOutput gives wrong answers.
+    '''
+    shifted = logits - np.max(logits, axis=axis, keepdims=True)
+    exp = np.exp(shifted)
+    return exp / np.sum(exp, axis=axis, keepdims=True)
+
+
 def model_dtype_to_np(model_dtype: str) -> object:
     return {
         'BOOL':   bool,
@@ -299,6 +312,18 @@ class TensorOutput(ModelOutput):
 
 
 class ClassificationOutput(ModelOutput):
+    '''
+    Parses Triton's built-in classification post-processing (`class_count`),
+    which returns only the top-N entries as score:class_id:class_name strings.
+
+    NOTE: because the server truncates to the N classes requested, the scores
+    this returns are an arbitrary subset of the model's logits. A softmax over
+    them normalizes against that subset, not the full class set, and so reports
+    confidences that are too high (see issue #5). To obtain real probabilities,
+    bind the output as a TensorOutput to get the complete logit vector and call
+    softmax() on it client-side.
+    '''
+
     def __init__(self, classes: int = 1):
         super().__init__()
         if classes < 1:

--- a/src/triton_api.py
+++ b/src/triton_api.py
@@ -202,9 +202,16 @@ class ImageInput(ModelInput):
         # https://medium.com/neuronio/how-to-deal-with-image-resizing-in-deep-learning-e5177fad7d89
         image = image.resize((self.width, self.height), Image.BILINEAR)
 
-        # Convert the image to a nparray
-        array = np.array(image).astype(
-            model_dtype_to_np(self.metadata.datatype))
+        # Convert the image to a nparray. Scaling produces fractional values, so
+        # it is only meaningful for a float input tensor; catch an integer one
+        # here rather than letting numpy raise an opaque casting error below.
+        dtype = np.dtype(model_dtype_to_np(self.metadata.datatype))
+        if self.scaling != ScalingMode.NONE and not np.issubdtype(dtype,
+                                                                  np.floating):
+            raise ValueError(
+                f'{self.scaling.name} scaling requires a floating-point input '
+                f'tensor, but the model expects {self.metadata.datatype}')
+        array = np.array(image).astype(dtype)
 
         # If the image is grayscale, add a channel axis (HW -> HWC)
         if array.ndim == 2:

--- a/src/triton_api.py
+++ b/src/triton_api.py
@@ -128,7 +128,8 @@ class TensorInput(ModelInput):
 
 class ImageInput(ModelInput):
     def __init__(self, scaling: ScalingMode = ScalingMode.NONE,
-                 layout: str = None):  # type: ignore[assignment]
+                 layout: str = None,  # type: ignore[assignment]
+                 size: tuple = None):  # type: ignore[assignment]
         super().__init__()
         self.scaling = scaling
         # Channel layout, 'NCHW' or 'NHWC'. If None it is taken from the model
@@ -136,6 +137,9 @@ class ImageInput(ModelInput):
         # does not declare a format (common for ONNX detectors, where `format`
         # cannot be set because the input tensor keeps an explicit batch dim).
         self.layout = layout
+        # Explicit (width, height) for models that declare dynamic spatial
+        # dimensions, where the shape metadata alone cannot tell us the size.
+        self.size = size
         self.channels = self.width = self.height = 0
         self._rank = 0  # rank of the model's input tensor (3 or 4)
 
@@ -171,6 +175,19 @@ class ImageInput(ModelInput):
             self.channels, self.height, self.width = shape[-3], shape[-2], shape[-1]
         else:  # NHWC
             self.height, self.width, self.channels = shape[-3], shape[-2], shape[-1]
+
+        # Triton reports -1 for any dimension the model leaves dynamic, which is
+        # not a usable image size. Fall back to an explicit size= if given.
+        if self.size is not None:
+            self.width, self.height = self.size
+        if self.width < 1 or self.height < 1:
+            raise ValueError(
+                f'Model declares dynamic spatial dimensions {shape}; pass '
+                'size=(width, height) to ImageInput() to choose the input size')
+        if self.channels < 1:
+            raise ValueError(
+                f'Model declares a dynamic channel count in {shape}; '
+                'ImageInput needs a fixed 1- or 3-channel input')
 
     def _process_one(self, image: Image.Image) -> np.ndarray:
         # Convert the image to the model's expected channel count
@@ -420,9 +437,14 @@ class Model:
                 if result.shape[0] > self.max_batch_size:
                     raise ValueError('Too many inputs in batch')
             else:
-                assert list(result.shape) == list(inputobj.metadata.shape), \
-                    (f'processed input shape {list(result.shape)} does not '
-                     f'match model shape {list(inputobj.metadata.shape)}')
+                # -1 marks a dimension the model leaves dynamic, which any
+                # size satisfies.
+                actual, expected = \
+                    list(result.shape), list(inputobj.metadata.shape)
+                assert len(actual) == len(expected) and \
+                    all(e == -1 or a == e for a, e in zip(actual, expected)), \
+                    (f'processed input shape {actual} does not '
+                     f'match model shape {expected}')
 
             # Create the InferInput object for this input
             req_inputs.append(tritonclient.grpc.InferInput(

--- a/src/triton_api.py
+++ b/src/triton_api.py
@@ -333,9 +333,19 @@ class ClassificationOutput(ModelOutput):
     def _parse_classification(self, c: bytes) -> Classification:
         '''
         Parse the score:class_id:class_name format that we receive from Triton
-        into a Classification object. 
+        into a Classification object.
+
+        The trailing name is only present when the model config names a
+        label_filename; without one Triton sends just score:class_id.
         '''
-        score, class_id, class_name = c.decode().split(':', maxsplit=2)
+        fields = c.decode().split(':', maxsplit=2)
+        if len(fields) == 2:
+            (score, class_id), class_name = fields, ''
+        elif len(fields) == 3:
+            score, class_id, class_name = fields
+        else:
+            raise ValueError(f'Malformed classification from Triton: {c!r}')
+
         return Classification(
             score=float(score),
             class_id=int(class_id),

--- a/src/triton_api.py
+++ b/src/triton_api.py
@@ -51,6 +51,7 @@ class ScalingMode(enum.Enum):
     NONE = 0
     INCEPTION = 1
     VGG = 2
+    NORM = 3  # scale pixel values to the range 0..1 (divide by 255), e.g. YOLO
 
 
 class Classification(NamedTuple):
@@ -126,31 +127,50 @@ class TensorInput(ModelInput):
 
 
 class ImageInput(ModelInput):
-    def __init__(self, scaling: ScalingMode = ScalingMode.NONE):
+    def __init__(self, scaling: ScalingMode = ScalingMode.NONE,
+                 layout: str = None):  # type: ignore[assignment]
         super().__init__()
         self.scaling = scaling
+        # Channel layout, 'NCHW' or 'NHWC'. If None it is taken from the model
+        # config's `format` field; pass it explicitly for models whose config
+        # does not declare a format (common for ONNX detectors, where `format`
+        # cannot be set because the input tensor keeps an explicit batch dim).
+        self.layout = layout
         self.channels = self.width = self.height = 0
+        self._rank = 0  # rank of the model's input tensor (3 or 4)
 
     def bind(self, model: 'Model', name: str):
         super().bind(model, name)
 
-        # Extract number of channels, height, and width from the input tensor
-        # shape, depending on the model's declared format (NHWC or NCHW).
-        expected_dims = 3 + (1 if self.model.can_batch else 0)
-        assert len(self.metadata.shape) == expected_dims
+        shape = list(self.metadata.shape)
+        self._rank = len(shape)
+        if self._rank not in (3, 4):
+            raise ValueError(
+                f'ImageInput expects a rank-3 or rank-4 input, got {shape}')
 
-        if self.config.format == model_config_pb2.ModelInput.Format.FORMAT_NHWC:
-            self.height = self.metadata.shape[1 if self.model.can_batch else 0]
-            self.width = self.metadata.shape[2 if self.model.can_batch else 1]
-            self.channels = \
-                self.metadata.shape[3 if self.model.can_batch else 2]
-        elif self.config.format == model_config_pb2.ModelInput.Format.FORMAT_NCHW:
-            self.channels = \
-                self.metadata.shape[1 if self.model.can_batch else 0]
-            self.height = self.metadata.shape[2 if self.model.can_batch else 1]
-            self.width = self.metadata.shape[3 if self.model.can_batch else 2]
-        else:
-            raise ValueError('Unexpected input format')
+        # Determine the channel layout: an explicit override wins, otherwise
+        # fall back to the model config's declared format.
+        layout = self.layout
+        if layout is None:
+            fmt = self.config.format
+            if fmt == model_config_pb2.ModelInput.Format.FORMAT_NCHW:
+                layout = 'NCHW'
+            elif fmt == model_config_pb2.ModelInput.Format.FORMAT_NHWC:
+                layout = 'NHWC'
+            else:
+                raise ValueError(
+                    'Model config does not declare an input format; pass '
+                    "layout='NCHW' or 'NHWC' to ImageInput()")
+        if layout not in ('NCHW', 'NHWC'):
+            raise ValueError(f'Unknown layout {layout!r}')
+        self.layout = layout
+
+        # Channels/height/width are the trailing three dims; any leading batch
+        # dimension (fixed like [1, ...] or dynamic like [-1, ...]) is ignored.
+        if layout == 'NCHW':
+            self.channels, self.height, self.width = shape[-3], shape[-2], shape[-1]
+        else:  # NHWC
+            self.height, self.width, self.channels = shape[-3], shape[-2], shape[-1]
 
     def _process_one(self, image: Image.Image) -> np.ndarray:
         # Convert the image to the model's expected channel count
@@ -173,9 +193,11 @@ class ImageInput(ModelInput):
         if array.ndim == 2:
             array = array[:, :, np.newaxis]
 
-        # Apply scaling to the range -1..1 for Inception models
+        # Apply optional pixel scaling.
         if self.scaling == ScalingMode.NONE:
             pass
+        elif self.scaling == ScalingMode.NORM:
+            array /= 255.0
         elif self.scaling == ScalingMode.INCEPTION:
             array /= 127.5
             array -= 1
@@ -197,14 +219,15 @@ class ImageInput(ModelInput):
             raise ValueError('Input expects exactly one image')
 
         # Process all of the images into a batch in NHWC format
-        processed = np.stack([ self._process_one(image) for image in value ])
+        processed = np.stack([self._process_one(image) for image in value])
 
-        # If the model expects (N)CHW instead, re-arrange the axes
-        if self.config.format == model_config_pb2.ModelInput.FORMAT_NCHW:
+        # If the model expects channels-first, re-arrange NHWC -> NCHW
+        if self.layout == 'NCHW':
             processed = np.transpose(processed, (0, 3, 1, 2))
 
-        # Return either a single or a batch of processed images
-        if not self.model.can_batch:
+        # Keep the leading batch axis only if the model's input tensor has one
+        # (rank 4). A rank-3 input wants a single [C,H,W] / [H,W,C] array.
+        if self._rank == 3:
             return processed[0]
         return processed
 
@@ -397,9 +420,9 @@ class Model:
                 if result.shape[0] > self.max_batch_size:
                     raise ValueError('Too many inputs in batch')
             else:
-                assert result.shape[0] == inputobj.metadata.shape[0]
-                assert result.shape[1] == inputobj.metadata.shape[1]
-                assert result.shape[2] == inputobj.metadata.shape[2]
+                assert list(result.shape) == list(inputobj.metadata.shape), \
+                    (f'processed input shape {list(result.shape)} does not '
+                     f'match model shape {list(inputobj.metadata.shape)}')
 
             # Create the InferInput object for this input
             req_inputs.append(tritonclient.grpc.InferInput(
@@ -461,46 +484,57 @@ def main():
     import pprint
     import time
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description='Submit image(s) to a Triton model and print the results.')
     parser.add_argument('-v', '--verbose', action='store_true')
     parser.add_argument('-m', '--model-name', required=True)
     parser.add_argument('-x', '--model-version', default='')
-    parser.add_argument('-b', '--batch-size', type=int, default=1)
-    parser.add_argument('-c', '--classes', type=int, default=3)
+    parser.add_argument('-c', '--classes', type=int, default=3,
+                        help='classes to request (classification mode)')
     parser.add_argument('-t', '--image-transform',
-                        choices=['NONE', 'INCEPTION', 'VGG'], default='NONE')
+                        choices=['NONE', 'NORM', 'INCEPTION', 'VGG'],
+                        default='NONE')
+    parser.add_argument('-l', '--layout', choices=['NCHW', 'NHWC'], default=None,
+                        help="channel layout when the model config omits `format`")
+    parser.add_argument('--raw', action='store_true',
+                        help='return the raw output tensor instead of parsing '
+                             'classifications (e.g. for detection models)')
     parser.add_argument('-u', '--url', default='localhost:8001')
     parser.add_argument('images', nargs='+')
     args = parser.parse_args()
 
-    # This script only supports Inception input transformation right now
-    assert args.image_transform == 'INCEPTION'
+    model = initialize_model(args.url, args.model_name, args.verbose,
+                             args.model_version)
 
-    model = initialize_model(args.url, args.model_name, args.verbose, args.model_version)
-    
-    model.input = ImageInput(scaling=ScalingMode.INCEPTION)
-    model.output = ClassificationOutput(classes=3)
+    # Bind the first input as an image and the first output for our result,
+    # by their actual tensor names (not every model calls them input/output).
+    in_name = model.metadata.inputs[0].name
+    out_name = model.metadata.outputs[0].name
 
-    # Load images
+    setattr(model, in_name, ImageInput(
+        scaling=ScalingMode[args.image_transform], layout=args.layout))
+    if args.raw:
+        setattr(model, out_name, TensorOutput())
+    else:
+        setattr(model, out_name, ClassificationOutput(classes=args.classes))
+
     images = [Image.open(path) for path in args.images]
 
-    # Request inference
-    # TODO: We should batch these according to the models max_batch_size
     start = time.perf_counter()
-    if len(images) > 1 and args.batch_size == 1:
-        for image in images:
-            result = model.infer(image)
-            pprint.pprint(result.output)
-    else: 
-        result = model.infer(images)
-        pprint.pprint(result.output)
+    for image in images:
+        result = model.infer(image)
+        value = getattr(result, out_name)
+        if args.raw:
+            arr = np.asarray(value)
+            print(f'{out_name}: shape={arr.shape} dtype={arr.dtype} '
+                  f'min={float(arr.min()):.4f} max={float(arr.max()):.4f}')
+        else:
+            pprint.pprint(value)
     stop = time.perf_counter()
 
-    # Display the output
-    print(
-        f'Processed {len(images)} images in {(stop - start):0.3f} seconds '
-        f'({(stop - start)/len(images):0.3f} sec per image)'
-    )
+    n = len(images)
+    print(f'Processed {n} image(s) in {(stop - start):0.3f} s '
+          f'({(stop - start) / n:0.3f} s per image)')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Independent of #9** (that one is Dockerfile-only); this is the base of the Python stack.

`triton_api.py` could not talk to an ONNX detector at all, and carried three latent bugs.

### Support models whose config declares no input format
An ONNX detector keeps an explicit batch dimension on its input, and a config with an explicit batch dim **cannot** declare a `format`. `ImageInput` derived the layout solely from that field, so it rejected such models outright, and assumed tensor rank followed `max_batch_size` — untrue when the batch dim is fixed rather than dynamic.

- accept an explicit `layout='NCHW'/'NHWC'`
- take C/H/W from the **trailing** three dims, and keep or drop the batch axis by the tensor's actual rank
- add `NORM` scaling (÷255) for YOLO-style inputs
- `main()` binds by the model's real tensor names instead of assuming `input`/`output`, plus a `--raw` mode

### Correctness fixes
- **dynamic dimensions**: Triton reports `-1` for anything a model leaves dynamic. `bind()` copied that straight into width/height (so `resize((-1,-1))` failed), and the shape check compared for exact equality, rejecting valid input for a model with a dynamic batch axis. Now `-1` is a wildcard, and dynamic spatial dims are reported clearly with a `size=(w,h)` escape hatch.
- **integer input tensors**: scaling after casting to a `TYPE_UINT8` input raised numpy's opaque `same_kind` casting error. Caught up front with a message that says what's wrong.
- **models without a label file**: Triton only appends `:class_name` when the config names a `label_filename`. Without one it sends `score:class_id`, and the three-way unpack raised `ValueError: not enough values to unpack`, so **`ClassificationOutput` was broken for any model shipped without labels**. (Found by the test suite in a later PR in this stack.)

Also adds a `softmax()` helper and documents why `ClassificationOutput`'s own scores can't be normalized correctly — see #5, fixed at the top of this stack.

---
📚 Stack: **2/6** · base of the Python chain → #11 detection → tests → vision_msgs → logits