### PR TITLE
Client: normalize over the full logit vector (fixes #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,13 @@ optional; without them the node publishes numeric ids and logs a warning.
 ### Other parameters
 
 `~triton_server_url`, `~classifier_model`, `~layout` (`NCHW`/`NHWC`, needed when
-the model config declares no `format`), `~classes` (classification),
-`~confidence_threshold` and `~iou_threshold` (detection).
+the model config declares no `format`), `~classes` and `~activation`
+(classification), `~confidence_threshold` and `~iou_threshold` (detection).
+
+`~activation` defaults to `softmax`, which normalizes the model's complete
+logit vector locally so `score` is a probability in [0, 1] as vision_msgs
+expects. Use `sigmoid` for multi-label models, or `''` to publish the server's
+raw logits instead.
 
 
 ## Installation

--- a/src/classifier_node.py
+++ b/src/classifier_node.py
@@ -137,10 +137,10 @@ def build_classification(classifications, image_msg):
     '''
     Convert triton_api Classifications into a vision_msgs/Classification2D.
 
-    NOTE: vision_msgs says score "should lie in the range [0-1]", but Triton
-    applies no activation, so these are raw logits. They cannot be normalized
-    correctly here because class_count only returns the top N of them -- see
-    issue #5.
+    vision_msgs says score "should lie in the range [0-1]". The node asks
+    ClassificationOutput to apply a softmax over the model's complete logit
+    vector by default, so that holds; with ~activation='' the scores are the
+    server's raw logits instead and it does not.
     '''
     message = Classification2D()
     message.header = image_msg.header
@@ -170,17 +170,26 @@ def main():
     input_name = model.metadata.inputs[0].name
     output_name = model.metadata.outputs[0].name
 
+    labels = load_class_labels()
+
     if task == 'detection':
         image_input = ImageInput(scaling=ScalingMode.NORM, letterbox=True,
                                  layout=rospy.get_param('~layout', None))
         output = DetectionOutput(
             confidence=rospy.get_param('~confidence_threshold', 0.25),
-            iou=rospy.get_param('~iou_threshold', 0.45))
+            iou=rospy.get_param('~iou_threshold', 0.45),
+            labels=labels or None)
     else:
         image_input = ImageInput(scaling=ScalingMode.INCEPTION,
                                  layout=rospy.get_param('~layout', None))
+        # Normalize locally by default so that `score` is a probability, as
+        # vision_msgs expects. Set ~activation to '' for the server's raw
+        # logits, or to 'sigmoid' for a multi-label model.
+        activation = rospy.get_param('~activation', 'softmax') or None
         output = ClassificationOutput(
-            classes=rospy.get_param('~classes', 3))
+            classes=rospy.get_param('~classes', 3),
+            activation=activation,
+            labels=labels or None)
 
     setattr(model, input_name, image_input)
     setattr(model, output_name, output)
@@ -196,7 +205,6 @@ def main():
 
     # Advertise where the id -> name map lives. Latched, so that subscribers
     # which come up after us still receive it.
-    labels = load_class_labels()
     info = VisionInfo()
     info.header.stamp = rospy.Time.now()
     info.method = model_name

--- a/src/triton_api.py
+++ b/src/triton_api.py
@@ -374,6 +374,16 @@ class ModelOutput:
         except StopIteration as exc:
             raise ValueError(f'No model output named "{name}"') from exc
 
+    @property
+    def class_count(self) -> int:
+        '''
+        How many classes to ask Triton to pick out server-side.
+
+        0 (the default) means "return the output tensor as-is". Only
+        ClassificationOutput overrides this.
+        '''
+        return 0
+
     def process(self, value: np.ndarray) -> Any:
         '''
         Process the "raw" ndarray output from the inference result and
@@ -391,22 +401,78 @@ class TensorOutput(ModelOutput):
 
 class ClassificationOutput(ModelOutput):
     '''
-    Parses Triton's built-in classification post-processing (`class_count`),
-    which returns only the top-N entries as score:class_id:class_name strings.
+    Returns the top `classes` results of a classification model.
 
-    NOTE: because the server truncates to the N classes requested, the scores
-    this returns are an arbitrary subset of the model's logits. A softmax over
-    them normalizes against that subset, not the full class set, and so reports
-    confidences that are too high (see issue #5). To obtain real probabilities,
-    bind the output as a TensorOutput to get the complete logit vector and call
-    softmax() on it client-side.
+    There are two ways to get them, and the choice is forced by a quirk of the
+    protocol. Triton applies no activation function to model outputs, so the
+    values a model emits are raw logits. Its built-in `class_count`
+    post-processing picks the top N server-side and sends them back as
+    score:class_id:class_name strings -- but by then the other logits are gone,
+    and a softmax over what survives normalizes against an arbitrary subset,
+    reporting confidences that are far too high (issue #5).
+
+    So `activation` decides both questions at once:
+
+      None (default)  ask the server for the top N. Cheap, and the class names
+                      come from the model's label_filename if it has one, but
+                      `score` is a raw logit, not a probability.
+
+      'softmax'       fetch the complete logit vector, normalize it locally
+                      over every class, then take the top N. `score` is then a
+                      real probability in [0, 1] that sums to 1 across all
+                      classes. Use this for single-label classifiers.
+
+      'sigmoid'       as above but squash each logit independently, for
+                      multi-label models where classes are not exclusive.
+
+    Fetching the full vector costs almost nothing -- a few kilobytes against
+    the image you just uploaded -- so prefer an activation unless you have a
+    reason not to. Class names are not sent in that mode; pass `labels` to name
+    them locally.
     '''
 
-    def __init__(self, classes: int = 1):
+    ACTIVATIONS = (None, 'softmax', 'sigmoid')
+
+    def __init__(self, classes: int = 1, activation: str = None,  # type: ignore[assignment]
+                 labels: List[str] = None):  # type: ignore[assignment]
         super().__init__()
         if classes < 1:
             raise ValueError('Must request at least one class')
+        if activation not in self.ACTIVATIONS:
+            raise ValueError(
+                f'activation must be one of {self.ACTIVATIONS}, got {activation!r}')
         self.classes = classes
+        self.activation = activation
+        self.labels = labels
+
+    @property
+    def class_count(self) -> int:
+        # Only let the server truncate when we are not normalizing locally: an
+        # activation is only correct over the complete set of logits.
+        return 0 if self.activation else self.classes
+
+    def _class_name(self, class_id: int) -> str:
+        if self.labels is not None and 0 <= class_id < len(self.labels):
+            return self.labels[class_id]
+        return ''
+
+    def _activate(self, logits: np.ndarray) -> np.ndarray:
+        if self.activation == 'softmax':
+            return softmax(logits, axis=-1)
+        # sigmoid, computed in a form that does not overflow for large |x|
+        return np.where(logits >= 0,
+                        1.0 / (1.0 + np.exp(-np.abs(logits))),
+                        np.exp(-np.abs(logits)) / (1.0 + np.exp(-np.abs(logits))))
+
+    def _top_classes(self, logits: np.ndarray) -> List[Classification]:
+        '''Normalize a full logit vector, then take the top `classes` of it.'''
+        scores = self._activate(np.asarray(logits, dtype=np.float64))
+        ranking = np.argsort(scores)[::-1][:self.classes]
+        return [
+            Classification(score=float(scores[i]), class_id=int(i),
+                           class_name=self._class_name(int(i)))
+            for i in ranking
+        ]
 
     def _parse_classification(self, c: bytes) -> Classification:
         '''
@@ -433,6 +499,22 @@ class ClassificationOutput(ModelOutput):
     def process(self, value: np.ndarray) \
             -> Union[List[List[Classification]], List[Classification]]:
 
+        if self.activation:
+            # A full logit vector per input, so rank locally.
+            if self.model.can_batch:
+                if value.ndim != 2:
+                    raise ValueError(
+                        'Expected 2 dimensions for a batched output')
+                return [self._top_classes(row) for row in value]
+
+            # A leading 1 here belongs to the model's own output shape.
+            if value.ndim == 2 and value.shape[0] == 1:
+                value = value[0]
+            if value.ndim != 1:
+                raise ValueError('Expected a 1-dimensional logit vector')
+            return self._top_classes(value)
+
+        # Triton already picked the top N and encoded them as strings.
         if value.ndim == 2:  # batched
             return [
                 [self._parse_classification(b) for b in a]
@@ -701,7 +783,7 @@ class Model:
 
             req_outputs.append(tritonclient.grpc.InferRequestedOutput(
                 name=outputobj.name,
-                class_count=getattr(outputobj, 'classes', 0)  # hacky
+                class_count=outputobj.class_count,
             ))
 
         # Submit the request to the inference server!

--- a/src/triton_api.py
+++ b/src/triton_api.py
@@ -31,9 +31,11 @@ def softmax(logits: np.ndarray, axis: int = -1) -> np.ndarray:
     '''
     Convert a *complete* vector of logits into probabilities.
 
-    Triton does not apply an activation function to model outputs. Apply this to
-    the full output tensor (bind the output as a TensorOutput); applying it to
-    the truncated top-N scores from ClassificationOutput gives wrong answers.
+    Most callers do not need this directly: pass activation='softmax' to
+    ClassificationOutput and it normalizes the full logit vector for you.
+    If you do call it, apply it only to a complete tensor (e.g. from a
+    TensorOutput); softmaxing a truncated top-N -- or scores that were
+    already activated -- gives wrong answers.
     '''
     shifted = logits - np.max(logits, axis=axis, keepdims=True)
     exp = np.exp(shifted)
@@ -77,8 +79,10 @@ class Classification(NamedTuple):
     A single possible classification result for an input. Multiple of these
     Classification objects may be returned.
 
-    Note that the score is a "raw" value, not a percentage; apply softmax or
-    a similar function for that.
+    What `score` means depends on how it was produced: with an activation
+    configured on ClassificationOutput it is already a probability in [0, 1]
+    (do NOT softmax it again); with activation=None it is the server's raw
+    logit.
     '''
     score: float
     class_id: int
@@ -409,6 +413,8 @@ class ModelOutput:
         self.config: model_config_pb2.ModelOutput = None  # type: ignore
         self.metadata: service_pb2.ModelMetadataResponse.TensorMetadata = \
             None  # type: ignore
+        # Optional id -> name list, set by subclasses that take `labels`.
+        self.labels: List[str] = None  # type: ignore
 
     def bind(self, model: 'Model', name: str):
         '''
@@ -438,6 +444,45 @@ class ModelOutput:
         ClassificationOutput overrides this.
         '''
         return 0
+
+    def _class_name(self, class_id: int) -> str:
+        '''
+        Name a class from the `labels` list. Out-of-range ids (or no labels
+        at all) fall back to the numeric id as a string, so the field is
+        never silently empty.
+        '''
+        if self.labels is not None and 0 <= class_id < len(self.labels):
+            return self.labels[class_id]
+        return str(class_id)
+
+    def _per_input(self, value: np.ndarray, rank: int, what: str):
+        '''
+        Split a raw output tensor into per-input pieces of the given rank:
+        a list of arrays for a batching model, a single bare array otherwise.
+
+        Only a batching model's leading axis is a batch; for a non-batching
+        model a leading 1 belongs to the model's own output shape. Trailing
+        singleton axes (the [N, C, 1, 1] shape of some pooled classifier
+        heads) carry no information and are squeezed away first.
+        '''
+        expected = rank + (1 if self.model.can_batch else 0)
+        while value.ndim > expected and value.shape[-1] == 1:
+            value = value[..., 0]
+
+        if self.model.can_batch:
+            if value.ndim != expected:
+                raise ValueError(
+                    f'Expected {expected} dimensions for a batched {what}, '
+                    f'got {tuple(value.shape)}')
+            return list(value)
+
+        if value.ndim == rank + 1 and value.shape[0] == 1:
+            value = value[0]
+        if value.ndim != rank:
+            raise ValueError(
+                f'Expected a {rank}-dimensional {what}, '
+                f'got {tuple(value.shape)}')
+        return value
 
     def process(self, value: np.ndarray) -> Any:
         '''
@@ -506,23 +551,29 @@ class ClassificationOutput(ModelOutput):
         # activation is only correct over the complete set of logits.
         return 0 if self.activation else self.classes
 
-    def _class_name(self, class_id: int) -> str:
-        if self.labels is not None and 0 <= class_id < len(self.labels):
-            return self.labels[class_id]
-        return ''
-
     def _activate(self, logits: np.ndarray) -> np.ndarray:
         if self.activation == 'softmax':
             return softmax(logits, axis=-1)
         # sigmoid, computed in a form that does not overflow for large |x|
-        return np.where(logits >= 0,
-                        1.0 / (1.0 + np.exp(-np.abs(logits))),
-                        np.exp(-np.abs(logits)) / (1.0 + np.exp(-np.abs(logits))))
+        e = np.exp(-np.abs(logits))
+        return np.where(logits >= 0, 1.0, e) / (1.0 + e)
 
     def _top_classes(self, logits: np.ndarray) -> List[Classification]:
         '''Normalize a full logit vector, then take the top `classes` of it.'''
-        scores = self._activate(np.asarray(logits, dtype=np.float64))
-        ranking = np.argsort(scores)[::-1][:self.classes]
+        logits = np.asarray(logits, dtype=np.float64)
+        if not np.all(np.isfinite(logits)):
+            # A NaN -- or an inf, which softmax's max-shift turns into NaN --
+            # sorts ahead of every real value and would be published as the
+            # top score. Fail loudly instead.
+            raise ValueError('Model returned non-finite logits')
+
+        # Rank on the raw logits, which both activations preserve
+        # monotonically. The activated scores saturate (float64 sigmoid is
+        # exactly 1.0 past |x| ~ 37) and would tie in arbitrary order; a
+        # stable sort on the logits keeps genuine ties in ascending-id order,
+        # matching the server-side ranking.
+        ranking = np.argsort(-logits, kind='stable')[:self.classes]
+        scores = self._activate(logits)
         return [
             Classification(score=float(scores[i]), class_id=int(i),
                            class_name=self._class_name(int(i)))
@@ -539,13 +590,18 @@ class ClassificationOutput(ModelOutput):
         '''
         fields = c.decode().split(':', maxsplit=2)
         if len(fields) == 2:
-            # Tolerated, but worth one loud note: without label_filename in the
-            # model config every published class_name will be empty.
-            warnings.warn(
-                'Triton returned classifications without class names; the '
-                'model config likely does not set label_filename',
-                stacklevel=2)
-            (score, class_id), class_name = fields, ''
+            # No server-side name (the model config has no label_filename);
+            # fall back to caller-supplied labels so they are honored in this
+            # mode too, and warn once when there is nothing to fall back on.
+            score, class_id = fields
+            if self.labels is not None:
+                class_name = self._class_name(int(class_id))
+            else:
+                warnings.warn(
+                    'Triton returned classifications without class names; '
+                    'the model config likely does not set label_filename',
+                    stacklevel=2)
+                class_name = ''
         elif len(fields) == 3:
             score, class_id, class_name = fields
         else:
@@ -562,17 +618,9 @@ class ClassificationOutput(ModelOutput):
 
         if self.activation:
             # A full logit vector per input, so rank locally.
-            if self.model.can_batch:
-                if value.ndim != 2:
-                    raise ValueError(
-                        'Expected 2 dimensions for a batched output')
+            value = self._per_input(value, 1, 'logit vector')
+            if isinstance(value, list):
                 return [self._top_classes(row) for row in value]
-
-            # A leading 1 here belongs to the model's own output shape.
-            if value.ndim == 2 and value.shape[0] == 1:
-                value = value[0]
-            if value.ndim != 1:
-                raise ValueError('Expected a 1-dimensional logit vector')
             return self._top_classes(value)
 
         # Triton already picked the top N and encoded them as strings.
@@ -614,11 +662,6 @@ class DetectionOutput(ModelOutput):
         self.confidence = confidence
         self.iou = iou
         self.labels = labels
-
-    def _class_name(self, class_id: int) -> str:
-        if self.labels is not None and 0 <= class_id < len(self.labels):
-            return self.labels[class_id]
-        return str(class_id)
 
     @staticmethod
     def _nms(boxes: np.ndarray, scores: np.ndarray, iou: float) -> List[int]:
@@ -743,17 +786,9 @@ class DetectionOutput(ModelOutput):
     def process(self, value: np.ndarray) \
             -> Union[List[List[Detection]], List[Detection]]:
 
-        # Only a batching model's leading axis is a batch; for a non-batching
-        # model a leading 1 belongs to the model's own output shape.
-        if self.model.can_batch:
-            if value.ndim != 3:
-                raise ValueError('Expected 3 dimensions for a batched output')
+        value = self._per_input(value, 2, 'detection output')
+        if isinstance(value, list):
             return [self._process_one(a) for a in value]
-
-        if value.ndim == 3 and value.shape[0] == 1:
-            value = value[0]
-        if value.ndim != 2:
-            raise ValueError('Expected a 2-dimensional detection output')
         return self._process_one(value)
 
 
@@ -975,6 +1010,13 @@ def main():
     mode.add_argument('--raw', action='store_true',
                       help='return the raw output tensor without parsing')
 
+    parser.add_argument('--activation', choices=['softmax', 'sigmoid', 'none'],
+                        default='softmax',
+                        help='classification score normalization; the default '
+                             "matches the ROS node's ~activation, so this "
+                             "tool reproduces the node's published scores "
+                             "('none' prints the server's raw logits)")
+
     parser.add_argument('images', nargs='+')
     args = parser.parse_args()
 
@@ -1001,7 +1043,8 @@ def main():
         setattr(model, out_name, DetectionOutput())
     else:
         setattr(model, out_name, ClassificationOutput(
-            classes=args.classes if args.classes is not None else 3))
+            classes=args.classes if args.classes is not None else 3,
+            activation=None if args.activation == 'none' else args.activation))
 
     images = [Image.open(path) for path in args.images]
 

--- a/tests/test_triton_api.py
+++ b/tests/test_triton_api.py
@@ -392,6 +392,45 @@ def test_activation_labels_name_the_classes():
         assert c.class_name == f'digit-{c.class_id}'
 
 
+def test_activation_rejects_non_finite_logits():
+    '''NaN (or inf, which softmax turns into NaN) must not rank first.'''
+    output = triton_api.ClassificationOutput(classes=3, activation='softmax')
+    with pytest.raises(ValueError, match='non-finite'):
+        output._top_classes(np.array([1.0, np.nan, 2.0]))
+    with pytest.raises(ValueError, match='non-finite'):
+        output._top_classes(np.array([1.0, np.inf, 2.0]))
+
+
+def test_saturated_sigmoid_still_ranks_by_logit():
+    '''Logits 50 and 40 both sigmoid to exactly 1.0; ranking must not tie.'''
+    output = triton_api.ClassificationOutput(classes=2, activation='sigmoid')
+    logits = np.zeros(100)
+    logits[3], logits[7] = 50.0, 40.0
+    top = output._top_classes(logits)
+    assert [c.class_id for c in top] == [3, 7]
+    assert top[0].score == top[1].score == 1.0
+
+
+def test_activation_accepts_trailing_singleton_axes():
+    '''Pooled classifier heads emit [1, C, 1, 1]; the squeeze must cope.'''
+    model, _ = make_model('mnist', response='gradient')
+    model.Input3 = triton_api.ImageInput(layout='NCHW')
+    model.Plus214_Output_0 = triton_api.ClassificationOutput(
+        classes=3, activation='softmax')
+
+    logits = np.arange(10, dtype=np.float32).reshape(1, 10, 1, 1)
+    results = model.Plus214_Output_0.process(logits)
+    assert [c.class_id for c in results] == [9, 8, 7]
+
+
+def test_labels_also_name_classes_in_server_top_n_mode():
+    '''labels= must not be silently inert when activation is None.'''
+    digits = [f'digit-{i}' for i in range(10)]
+    output = triton_api.ClassificationOutput(classes=3, labels=digits)
+    parsed = output._parse_classification(b'6.365949:5')
+    assert parsed.class_name == 'digit-5'
+
+
 def test_rejects_an_unknown_activation():
     with pytest.raises(ValueError, match='activation must be one of'):
         triton_api.ClassificationOutput(classes=3, activation='relu')

--- a/tests/test_triton_api.py
+++ b/tests/test_triton_api.py
@@ -305,6 +305,86 @@ def test_classification_handles_a_model_without_labels():
         output._parse_classification(b'nonsense')
 
 
+def test_softmax_activation_does_not_let_the_server_truncate():
+    '''The whole point: an activation needs every logit, so class_count is 0.'''
+    model, client = make_model('mnist', response='gradient')
+    model.Input3 = triton_api.ImageInput(layout='NCHW')
+    model.Plus214_Output_0 = triton_api.ClassificationOutput(
+        classes=3, activation='softmax')
+
+    model.infer(Image.new('L', (28, 28)))
+
+    requested = client.last_request.outputs[0]._output
+    assert requested.parameters['classification'].int64_param == 0
+
+
+def test_softmax_activation_yields_real_probabilities():
+    model, _ = make_model('mnist', response='gradient')
+    model.Input3 = triton_api.ImageInput(layout='NCHW')
+    # Ask for all ten so we can check they form a distribution.
+    model.Plus214_Output_0 = triton_api.ClassificationOutput(
+        classes=10, activation='softmax')
+
+    results = model.infer(Image.new('L', (28, 28))).Plus214_Output_0
+
+    assert len(results) == 10
+    scores = [c.score for c in results]
+    assert all(0.0 <= s <= 1.0 for s in scores)
+    assert sum(scores) == pytest.approx(1.0)       # over the FULL class set
+    assert scores == sorted(scores, reverse=True)  # ranked best-first
+    assert len({c.class_id for c in results}) == 10
+
+
+def test_truncated_softmax_would_have_been_wrong():
+    '''
+    Demonstrates issue #5. Normalizing the server's top-3 overstates every
+    confidence, because the other seven logits are missing from the sum.
+    '''
+    model, _ = make_model('mnist', response='gradient')
+    model.Input3 = triton_api.ImageInput(layout='NCHW')
+    model.Plus214_Output_0 = triton_api.ClassificationOutput(
+        classes=10, activation='softmax')
+    correct = model.infer(Image.new('L', (28, 28))).Plus214_Output_0
+
+    # What you would get by softmaxing only the top 3 scores.
+    top3_logits = np.array([c.score for c in correct[:3]])
+    naive = triton_api.softmax(np.log(top3_logits))   # renormalize the subset
+
+    assert naive[0] > correct[0].score               # inflated
+    assert sum(naive) == pytest.approx(1.0)          # sums to 1 over a subset
+    assert sum(c.score for c in correct[:3]) < 1.0   # honest: leaves room
+
+
+def test_sigmoid_activation_is_independent_per_class():
+    model, _ = make_model('mnist', response='gradient')
+    model.Input3 = triton_api.ImageInput(layout='NCHW')
+    model.Plus214_Output_0 = triton_api.ClassificationOutput(
+        classes=10, activation='sigmoid')
+
+    results = model.infer(Image.new('L', (28, 28))).Plus214_Output_0
+    scores = [c.score for c in results]
+    assert all(0.0 <= s <= 1.0 for s in scores)
+    # multi-label: no requirement to sum to 1
+    assert sum(scores) != pytest.approx(1.0)
+
+
+def test_activation_labels_name_the_classes():
+    digits = [f'digit-{i}' for i in range(10)]
+    model, _ = make_model('mnist', response='gradient')
+    model.Input3 = triton_api.ImageInput(layout='NCHW')
+    model.Plus214_Output_0 = triton_api.ClassificationOutput(
+        classes=2, activation='softmax', labels=digits)
+
+    results = model.infer(Image.new('L', (28, 28))).Plus214_Output_0
+    for c in results:
+        assert c.class_name == f'digit-{c.class_id}'
+
+
+def test_rejects_an_unknown_activation():
+    with pytest.raises(ValueError, match='activation must be one of'):
+        triton_api.ClassificationOutput(classes=3, activation='relu')
+
+
 def test_softmax_normalizes_full_logits():
     model, _ = make_model('mnist', response='gradient')
     model.Input3 = triton_api.ImageInput(layout='NCHW')


### PR DESCRIPTION
**Stacked on #13.** Closes #5.

Triton applies no activation to model outputs, so scores come back as raw logits. The obvious fix — softmax them — wasn't available, because `class_count` makes the **server** pick the top N and discard the rest before we ever see them. Normalizing what survives divides by a partial sum and overstates every confidence.

The two problems are inseparable, so one parameter settles both: **stop asking the server to truncate.**

| `activation` | `class_count` sent | result |
| --- | --- | --- |
| `None` (unchanged default) | N | server picks top N; `score` is a raw logit |
| `'softmax'` | **0** | full vector → normalize over *all* classes → *then* rank and cut to N |
| `'sigmoid'` | **0** | same, independent per class (multi-label) |

### Cost
Fetching the whole vector is a few KB against the image just uploaded. The real cost is **class names**, which Triton only attaches to its own top-N strings — so `ClassificationOutput` takes a `labels` list to name them locally, the same way `DetectionOutput` does, and the same names the node publishes via `VisionInfo`.

### Verified live
Same MNIST input: raw logits `792.4, 416.8, 228.1` → probabilities `1.0, 0.0, 0.0`, summing to exactly 1.0 over all ten classes.

Six new tests, including one that **demonstrates the old bug**: softmaxing the server's top 3 inflates the leading score and sums to 1 over a subset, while the correct path leaves room for the classes it didn't return.

The node now normalizes by default, so its `Classification2D` scores satisfy vision_msgs' documented `[0-1]` range. `~activation: ''` restores the old raw logits.

*(This MNIST fixture saturates to exactly 1.0/0.0 — not a bug: `mnist-8` emits logits with a ~375 gap, so `exp(-375)` underflows. A normally-trained classifier gives graded probabilities.)*

Also replaces the `getattr(outputobj, 'classes', 0)  # hacky` line in `Model.infer` with a proper `class_count` property.

---
📚 Stack: **6/6** · tip