### PR TITLE
Node: mono8 input, subscriber tuning, VisionInfo int32 fix

### DIFF
--- a/src/classifier_node.py
+++ b/src/classifier_node.py
@@ -93,7 +93,9 @@ def publish_class_labels(model_name, labels):
     rospy.set_param(key, {str(i): name for i, name in enumerate(labels)})
 
     # The digest doubles as a version, so consumers can notice label changes.
-    return key, int(digest, 16)
+    # Masked to 31 bits: the message field is int32 and a full 8-hex-digit
+    # digest overflows it half the time.
+    return key, int(digest, 16) & 0x7FFFFFFF
 
 
 def on_image(model, output_name, publisher, builder, image_msg):

--- a/src/classifier_node.py
+++ b/src/classifier_node.py
@@ -45,6 +45,8 @@ from triton_api import (
     initialize_model,
 )
 
+_BRIDGE = CvBridge()
+
 
 def load_class_labels():
     '''
@@ -95,10 +97,10 @@ def publish_class_labels(model_name, labels):
 
 
 def on_image(model, output_name, publisher, builder, image_msg):
-    # Use the cv_bridge to convert to an OpenCV image object
-    img = CvBridge().imgmsg_to_cv2(image_msg)
-    # Convert the OpenCV image to a PIL image
-    pil_image = PilImage.fromarray(cv2.cvtColor(img, cv2.COLOR_BGR2RGB))
+    # cv_bridge converts whatever encoding arrives (mono8, bgr8, ...) to the
+    # rgb8 the model pipeline expects.
+    img = _BRIDGE.imgmsg_to_cv2(image_msg, desired_encoding='rgb8')
+    pil_image = PilImage.fromarray(img)
 
     try:
         result = model.infer(pil_image)

--- a/src/classifier_node.py
+++ b/src/classifier_node.py
@@ -264,10 +264,16 @@ def main():
     # Subscribe to the raw image data. image_transport publishes the raw
     # sensor_msgs/Image on the base topic itself -- only the other transports
     # get "<base topic>/<transport name>" subtopics -- so do not append /raw.
+    # The rospy defaults are an unbounded queue and a 64 KiB receive buffer,
+    # which is smaller than a single Image from a megapixel camera. Bound the
+    # queue so overload drops frames instead of growing memory, and size the
+    # buffer for several frames so the queue, not the socket, governs.
     rospy.Subscriber(
         image_topic,
         Image,
-        functools.partial(on_image, model, output_name, publisher, builder)
+        functools.partial(on_image, model, output_name, publisher, builder),
+        queue_size=rospy.get_param('~queue_size', 1),
+        buff_size=rospy.get_param('~buff_size', 2 ** 24),
     )
 
     rospy.spin()


### PR DESCRIPTION
Three node fixes found while integrating the classifier with a mono8 (grayscale) camera pipeline on the Pyxis backseat, stacked on #14.

- **Accept any input encoding via cv_bridge conversion.** `imgmsg_to_cv2` with no `desired_encoding` passes the source encoding through, and the following `cvtColor(BGR2RGB)` assumed three channels — a mono8 publisher crashed the callback. Asking cv_bridge for `rgb8` directly converts mono8 and replaces the hand-rolled BGR swap. Also hoists `CvBridge()` to module level instead of constructing per frame.
- **Parameterize subscriber `queue_size` / `buff_size`.** The subscriber used rospy defaults: an unbounded queue and a 64 KiB `buff_size`, smaller than a single Image from a megapixel camera (a classic rospy large-message trap). Defaults become `queue_size=1` (drop stale frames when inference is the bottleneck) and a 16 MiB buffer; both are `~params` so bursty sources can opt into deeper queues.
- **Keep `database_version` within int32.** `publish_class_labels` computed `int(digest, 16)` on an 8-hex-digit SHA-1 prefix, which exceeds the int32 `VisionInfo/database_version` whenever the top bit is set — a 50% chance of `SerializationError` at startup for any labeled model. Masked to 31 bits.

Verified live on the Pyxis backseat (Jetson, Noetic, Triton 2.35.0 grpc): 100/100 mono8 ISIIS frames through detection with zero drops, and labels advertised via VisionInfo after the int32 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)